### PR TITLE
add .a to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .dub
 docs.json
 __dummy.html
-*.o
+*.[ao]
 *.obj


### PR DESCRIPTION
when you use a repo as submodule its annoying that the .a file makes the submodule dirty.

not sure if there is a solution via dub to have all libs being compiled into a separate directory