### PR TITLE
Suppress some warnings

### DIFF
--- a/source/stdx/data/json/parser.d
+++ b/source/stdx/data/json/parser.d
@@ -35,11 +35,12 @@ unittest
     assert(value == value2);
 }
 
-import stdx.data.json.lexer;
-import stdx.data.json.value;
 import std.array : appender;
 import std.range : ElementType, isInputRange;
+import std.traits : isIntegral, isSomeChar;
 
+import stdx.data.json.lexer;
+import stdx.data.json.value;
 
 /**
  * Parses a JSON string or token range and returns the result as a


### PR DESCRIPTION
I was seeing the following when building as a dependency through dub:
```
.../.dub/packages/std_data_json-0.18.1/source/stdx/data/json/parser.d(55,32): Deprecation: stdx.data.json.lexer.isSomeChar is not visible from module parser
.../.dub/packages/std_data_json-0.18.1/source/stdx/data/json/parser.d(55,32): Deprecation: stdx.data.json.lexer.isSomeChar is not visible from module parser
.../.dub/packages/std_data_json-0.18.1/source/stdx/data/json/parser.d(55,66): Deprecation: stdx.data.json.lexer.isIntegral is not visible from module parser
.../.dub/packages/std_data_json-0.18.1/source/stdx/data/json/parser.d(120,32): Deprecation: stdx.data.json.lexer.isSomeChar is not visible from module parser
.../.dub/packages/std_data_json-0.18.1/source/stdx/data/json/parser.d(120,66): Deprecation: stdx.data.json.lexer.isIntegral is not visible from module parser
.../.dub/packages/std_data_json-0.18.1/source/stdx/data/json/parser.d(120,32): Deprecation: stdx.data.json.lexer.isSomeChar is not visible from module parser
.../.dub/packages/std_data_json-0.18.1/source/stdx/data/json/parser.d(120,66): Deprecation: stdx.data.json.lexer.isIntegral is not visible from module parser
.../.dub/packages/std_data_json-0.18.1/source/stdx/data/json/parser.d(120,32): Deprecation: stdx.data.json.lexer.isSomeChar is not visible from module parser
.../.dub/packages/std_data_json-0.18.1/source/stdx/data/json/parser.d(120,66): Deprecation: stdx.data.json.lexer.isIntegral is not visible from module parser
```