### PR TITLE
Fixed issues uncovered by the https://github.com/nst/JSONTestSuite/ test suite

### DIFF
--- a/source/stdx/data/json/lexer.d
+++ b/source/stdx/data/json/lexer.d
@@ -587,6 +587,13 @@ struct JSONLexerRange(Input, LexOptions options = LexOptions.init, String = stri
                     return;
                 }
             }
+
+            if (exponent == 0)
+            {
+                // No digits were read after decimal
+                setError("Missing fractional number part");
+                return;
+            }
         }
 
         // exponent
@@ -813,13 +820,16 @@ struct JSONLexerRange(Input, LexOptions options = LexOptions.init, String = stri
     testFail("-");
     testFail("+1");
     testFail("1.");
+    testFail("1..");
     testFail(".1");
     testFail("01");
     testFail("1e");
     testFail("1e+");
     testFail("1e-");
     testFail("1.e");
+    testFail("1.e1");
     testFail("1.e-");
+    testFail("1.e-1");
     testFail("1.ee");
     testFail("1.e-e");
     testFail("1.e+e");


### PR DESCRIPTION
Compared to std.json this module was much more compliant with the JSON standards. That said there were two issues that I found:

Segfault with deep nesting:
n_structure_100000_opening_arrays.json
n_structure_open_array_object.json

Because stdx.data.json.parseJSONValue recurses on the native stack it can overflow the stack and cause a segmentation fault when the input has deep nesting. To address this issue I added a parameter to parseJSONValue and toJSONValue to limit the the depth of nesting that they will accept in the input.

std.json has the same issue and uses the same solution. By default std.json doesn't limit the nesting depth, however I feel that these APIs should be "safe" by default (since users will likely pass unsafe/untrusted JSON to them) so I selected a default maximum nesting depth of 512 which should be enough for the vast majority of real-world JSON documents and which users dealing with deeply-nested documents can manually bypass at their own risk.

An alternative solution I considered would have been to rewrite stdx.data.json.parseJSONValue to use a state machine and an explicit stack on the heap (which would allow safe arbitrarily-deep nesting), however that would be a much more significant refactor which I did not want to pursue as a first recourse.

Failure to require a digit after a decimal place:
n_number_0.e1.json
n_number_2.e-3.json
n_number_2.e+3.json
n_number_2.e3.json
n_number_-2..json
n_number_real_without_fractional_part.json

This was a fairly minor issue. JSONLexerRange.parseNumber() was failing to ensure there was a digit after the decimal place in all cases. I added an additional check to the portion of that function dealing with decimal places to verify this requirement.