### PR TITLE
Replace 'in' with 'const'

### DIFF
--- a/source/stdx/data/json/generator.d
+++ b/source/stdx/data/json/generator.d
@@ -164,7 +164,7 @@ void writeJSON(GeneratorOptions options = GeneratorOptions.init, Output, Input)(
     }
 }
 /// ditto
-void writeJSON(GeneratorOptions options = GeneratorOptions.init, String, Output)(in ref JSONToken!String token, ref Output output)
+void writeJSON(GeneratorOptions options = GeneratorOptions.init, String, Output)(const ref JSONToken!String token, ref Output output)
     if (isOutputRange!(Output, char))
 {
     final switch (token.kind) with (JSONTokenKind)

--- a/source/stdx/data/json/lexer.d
+++ b/source/stdx/data/json/lexer.d
@@ -989,7 +989,7 @@ struct JSONLexerRange(Input, LexOptions options = LexOptions.init, String = stri
      * Note that the location is considered token meta data and thus does not
      * affect the comparison.
      */
-    bool opEquals(in ref JSONToken other) const nothrow @trusted
+    bool opEquals(const ref JSONToken other) const nothrow @trusted
     {
         if (this.kind != other.kind) return false;
 

--- a/source/stdx/data/json/parser.d
+++ b/source/stdx/data/json/parser.d
@@ -727,7 +727,7 @@ struct JSONParserNode(String)
      * Note that the location is considered part of the token and thus is
      * included in the comparison.
      */
-    bool opEquals(in ref JSONParserNode other)
+    bool opEquals(const ref JSONParserNode other)
     const nothrow
     {
         if (this.kind != other.kind) return false;


### PR DESCRIPTION
To avoid a future deprecation