### PR TITLE
fix a deprecation introduced by DMD 2.109.0

### DIFF
--- a/source/stdx/data/json/lexer.d
+++ b/source/stdx/data/json/lexer.d
@@ -607,7 +607,7 @@ struct JSONLexerRange(Input, LexOptions options = LexOptions.init, String = stri
                 return;
             }
 
-            bool negexp = void;
+            bool negexp = false;
             if (_input.front == '-')
             {
                 negexp = true;


### PR DESCRIPTION
`void` initialization of bools is no longer allowed in `@safe` code. A trivial fix.