### PR TITLE
chore: Clear up deprecations through the code base

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,13 +12,14 @@ jobs:
     name: "[${{ matrix.os }} | ${{ matrix.dc }}]"
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [ubuntu-latest, windows-latest]
         dc: [dmd-latest, ldc-latest]
-        arch: [x86_64]
+        include:
+            # No support for Apple Silicon from DMD at this time
+            - { os: macOS-latest, dc: ldc-latest }
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
-
+      - uses: actions/checkout@v4
       - name: Install D compiler
         uses: dlang-community/setup-dlang@v1
         with:
@@ -26,6 +27,5 @@ jobs:
       - name: Run tests
         env:
           DC: ${{matrix.dc}}
-          ARCH: ${{matrix.arch}}
         run: |
           dub test

--- a/source/stdx/data/json/generator.d
+++ b/source/stdx/data/json/generator.d
@@ -485,12 +485,12 @@ private void writeNumber(R)(ref R dst, BigInt num) @trusted
 
     auto num = toJSONValue("-67.199307");
     auto exp = -67.199307;
-    assert(num.get!double.approxEqual(exp));
+    assert(num.get!double.isClose(exp));
 
     auto snum = appender!string;
     snum.writeNumber!(GeneratorOptions.init)(JSONNumber(num.get!double));
     auto pnum = toJSONValue(snum.data);
-    assert(pnum.get!double.approxEqual(num.get!double));
+    assert(pnum.get!double.isClose(num.get!double));
 }
 
 @safe unittest // special float values

--- a/source/stdx/data/json/lexer.d
+++ b/source/stdx/data/json/lexer.d
@@ -607,17 +607,11 @@ struct JSONLexerRange(Input, LexOptions options = LexOptions.init, String = stri
                 return;
             }
 
-            bool negexp = void;
-            if (_input.front == '-')
-            {
-                negexp = true;
+            bool negexp = (_input.front == '-');
+            if (negexp)
                 skipChar();
-            }
-            else
-            {
-                negexp = false;
-                if (_input.front == '+') skipChar();
-            }
+            else if (_input.front == '+')
+                skipChar();
 
             if (_input.empty || !_input.front.isDigit)
             {
@@ -747,7 +741,7 @@ struct JSONLexerRange(Input, LexOptions options = LexOptions.init, String = stri
 @safe unittest
 {
     import std.exception;
-    import std.math : approxEqual, isNaN;
+    import std.math : isClose, isNaN;
 
     static double parseNumberHelper(LexOptions options, R)(ref R input, ref Location loc)
     {
@@ -765,7 +759,7 @@ struct JSONLexerRange(Input, LexOptions options = LexOptions.init, String = stri
         Location loc;
         auto strcopy = str;
         auto res = parseNumberHelper!options(strcopy, loc);
-        assert((res.isNaN && expected.isNaN) || approxEqual(res, expected), () @trusted {return res.to!string;}());
+        assert((res.isNaN && expected.isNaN) || isClose(res, expected), () @trusted {return res.to!string;}());
         assert(strcopy == remainder);
         assert(loc.line == 0);
         assert(loc.column == str.length - remainder.length, text(loc.column));
@@ -947,7 +941,7 @@ struct JSONLexerRange(Input, LexOptions options = LexOptions.init, String = stri
     @property bool boolean(bool value) pure nothrow @nogc
     {
         _kind = Kind.boolean;
-        _boolean = value;
+        () @trusted { _boolean = value; } ();
         return value;
     }
 
@@ -1287,7 +1281,7 @@ enum JSONTokenKind
      * yield a value converted to $(D double). Setting this property will
      * automatically update the number type to $(D Type.double_).
      */
-    @property double doubleValue() const nothrow @trusted @nogc
+    @property double doubleValue() const nothrow @trusted @nogc pure
     {
         final switch (_type)
         {

--- a/source/stdx/data/json/package.d
+++ b/source/stdx/data/json/package.d
@@ -948,7 +948,7 @@ unittest
         {
             if (a.kind == b.kind && a.kind == JSONParserNodeKind.literal) {
                 if (a.literal.kind == b.literal.kind && a.literal.kind == JSONTokenKind.number)
-                    return a.literal.number.approxEqual(b.literal.number);
+                    return a.literal.number.isClose(b.literal.number);
             }
             return a == b;
         }


### PR DESCRIPTION
Replaces `approxEqual` with `isClose` and add `pure` to `doubleValue` as it was otherwise failing to compile. As void initialization of bool is no longer safe, this led to two other minor code adjustments.